### PR TITLE
Add @Override annotations

### DIFF
--- a/src/net/pempek/unicode/UnicodeBOMInputStream.java
+++ b/src/net/pempek/unicode/UnicodeBOMInputStream.java
@@ -230,26 +230,20 @@ public class UnicodeBOMInputStream extends InputStream
     return this;
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  @Override
   public int read() throws IOException
   {
     return in.read();
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  @Override
   public int read(final byte b[]) throws  IOException,
                                           NullPointerException
   {
     return in.read(b, 0, b.length);
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  @Override
   public int read(final byte b[],
                   final int off,
                   final int len) throws IOException,
@@ -258,49 +252,37 @@ public class UnicodeBOMInputStream extends InputStream
     return in.read(b, off, len);
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  @Override
   public long skip(final long n) throws IOException
   {
     return in.skip(n);
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  @Override
   public int available() throws IOException
   {
     return in.available();
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  @Override
   public void close() throws IOException
   {
     in.close();
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  @Override
   public synchronized void mark(final int readlimit)
   {
     in.mark(readlimit);
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  @Override
   public synchronized void reset() throws IOException
   {
     in.reset();
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  @Override
   public boolean markSupported()
   {
     return in.markSupported();


### PR DESCRIPTION
It is good practice to use the `@Override` annotation whenever overriding a method. This allows the compiler to check to make sure you actually are overriding a method when you think you are (e.g. checks to ensure you don't accidentally have a typo). It also makes your code easier to understand because it is more obvious when methods are overwritten.

Also, you don't need to use `{@inheritDoc}` if you don't have javadoc comments on a subclass. Javadocs will be be generated based on the superclasses javadoc if no javadocs are present. You can use `{@inheritDoc}` however if you wish to write your own javadoc and include the respective superclass javadoc comments in the subclass javadocs.